### PR TITLE
Enable gzip compression for JSON and SVG.

### DIFF
--- a/playbooks/roles/lb/templates/etc/haproxy/haproxy-cfg.j2
+++ b/playbooks/roles/lb/templates/etc/haproxy/haproxy-cfg.j2
@@ -57,7 +57,7 @@ defaults
 frontend www-frontend
     mode http
     compression algo gzip
-    compression type text/html text/plain text/javascript application/javascript application/xml text/css
+    compression type text/html text/plain text/javascript application/javascript application/xml application/json text/css image/svg+xml
     timeout client 5000
 
     option httplog


### PR DESCRIPTION
Fixes #19.