### PR TITLE
Add cache hits number to header

### DIFF
--- a/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
+++ b/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
@@ -94,6 +94,7 @@ sub vcl_deliver {
   # If the page is already cached return a HIT header, otherwise MISS.
   if (obj.hits > 0) {
     set resp.http.X-Cache = "HIT";
+    set resp.http.X-Cache-Hits = obj.hits;
   } else {
     set resp.http.X-Cache = "MISS";
   }


### PR DESCRIPTION
Follow-up to 73aa332c49418bef4f14a208465f0c2b208c26e8.

See #47.