### PR TITLE
Standardize Accept-Encoding HTTP headers for Varnish

### DIFF
--- a/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
+++ b/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
@@ -52,6 +52,24 @@ sub vcl_recv {
 # sub vcl_fetch #
 #################
 sub vcl_fetch {
+  # Many requests contain Accept-Encoding HTTP headers.
+  # We standardize and remove these when unnecessary to make it easier to cache requests.
+  if (req.http.Accept-Encoding) {
+    # If the request URL has any of these extensions, remove the Accept-Encoding header as it is meaningless.
+   if (req.url ~ "\.(jpe?g|jpe|gif|png|css|js)$") {
+      remove req.http.Accept-Encoding;
+    # If the Accept-Encoding contains 'gzip' standardize it.
+    } elsif (req.http.Accept-Encoding ~ "gzip") {
+      set req.http.Accept-Encoding = "gzip";
+    # If the Accept-Encoding contains 'deflate' standardize it.
+    } elsif (req.http.Accept-Encoding ~ "deflate") {
+      set req.http.Accept-Encoding = "deflate";
+    # If the Accept-Encoding header isn't matched above, remove it.
+    } else {
+      remove req.http.Accept-Encoding;
+    }
+  }
+
   # Strip any cookies before an image/JS/CSS is inserted into cache.
   if (req.url ~ "\.(jpe?g|jpe|gif|png|css|js)$") {
      unset beresp.http.set-cookie;

--- a/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
+++ b/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
@@ -56,7 +56,7 @@ sub vcl_fetch {
   # We standardize and remove these when unnecessary to make it easier to cache requests.
   if (req.http.Accept-Encoding) {
     # If the request URL has any of these extensions, remove the Accept-Encoding header as it is meaningless.
-   if (req.url ~ "\.(jpe?g|jpe|gif|png|css|js)$") {
+   if (req.url ~ "\.(jpe?g|jpe|gif|png)$") {
       remove req.http.Accept-Encoding;
     # If the Accept-Encoding contains 'gzip' standardize it.
     } elsif (req.http.Accept-Encoding ~ "gzip") {

--- a/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
+++ b/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
@@ -56,7 +56,7 @@ sub vcl_fetch {
   # We standardize and remove these when unnecessary to make it easier to cache requests.
   if (req.http.Accept-Encoding) {
     # If the request URL has any of these extensions, remove the Accept-Encoding header as it is meaningless.
-   if (req.url ~ "\.(jpe?g|jpe|gif|png)$") {
+   if (req.url ~ "\.(jpe?g|jpe|gif|png|webp)$") {
       remove req.http.Accept-Encoding;
     # If the Accept-Encoding contains 'gzip' standardize it.
     } elsif (req.http.Accept-Encoding ~ "gzip") {
@@ -71,7 +71,7 @@ sub vcl_fetch {
   }
 
   # Strip any cookies before an image/JS/CSS is inserted into cache.
-  if (req.url ~ "\.(jpe?g|jpe|gif|png|css|js)$") {
+  if (req.url ~ "\.(jpe?g|jpe|gif|png|webp|svg|css|js)$") {
      unset beresp.http.set-cookie;
   }
 


### PR DESCRIPTION
See #47.

Trying to find a good balance between project specific configs and default configs and I think this one should be a default one.

Rule is from https://spin.atomicobject.com/2013/01/16/speed-up-website-varnish/ but only applied to `(jpe?g|jpe|gif|png|css|js)` files which we already use in fa850afc97d4d723ca8a6f43602e1df2c1c913ff.