### PR TITLE
Varnish: Don't allow cache purge if the `X-Forwarded-For` header is set.

### DIFF
--- a/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
+++ b/playbooks/roles/web/templates/etc/varnish/default.vcl.j2
@@ -58,7 +58,7 @@ sub vcl_hash {
 sub vcl_recv {
   # Allow purging.
   if (req.request == "PURGE") {
-      if (!client.ip ~ purge) {
+      if (req.http.X-Forwarded-For || !client.ip ~ purge) {
           error 405 "This IP is not allowed to send PURGE requests.";
       }
 


### PR DESCRIPTION
If the header is set we're handling a request by an external client. See https://info.varnish-software.com/blog/failure-to-purge-a-story-about-client.ip-and-proxies for background.

See #47.