### PR TITLE
Search `Vagrantfile.local.yml` relative to the `Vagrantfile` 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,24 +19,28 @@ atlantis_synced_folder_type = ""
 atlantis_synced_folder_smb_username = ""
 atlantis_synced_folder_smb_password = ""
 
-custom_settings = YAML.load_file 'Vagrantfile.local.yml'
-if custom_settings['synced_folder']['appflow_folder']
-  atlantis_synced_folder_appflow = custom_settings['synced_folder']['appflow_folder']
-end
-if custom_settings['synced_folder']['webdev_folder']
-  atlantis_synced_folder_webdev = custom_settings['synced_folder']['webdev_folder']
-end
-if custom_settings['synced_folder']['mount_options']
-  atlantis_synced_folder_mount_options = custom_settings['synced_folder']['mount_options']
-end
-if custom_settings['synced_folder']['type']
-  atlantis_synced_folder_type = custom_settings['synced_folder']['type']
-end
-if custom_settings['synced_folder']['smb_username']
-  atlantis_synced_folder_smb_username = custom_settings['synced_folder']['smb_username']
-end
-if custom_settings['synced_folder']['smb_password']
-  atlantis_synced_folder_smb_password = custom_settings['synced_folder']['smb_password']
+dir = File.dirname(File.expand_path(__FILE__))
+
+if File.file?("#{dir}/Vagrantfile.local.yml")
+  custom_settings = YAML.load_file("#{dir}/Vagrantfile.local.yml")
+  if custom_settings['synced_folder']['appflow_folder']
+    atlantis_synced_folder_appflow = custom_settings['synced_folder']['appflow_folder']
+  end
+  if custom_settings['synced_folder']['webdev_folder']
+    atlantis_synced_folder_webdev = custom_settings['synced_folder']['webdev_folder']
+  end
+  if custom_settings['synced_folder']['mount_options']
+    atlantis_synced_folder_mount_options = custom_settings['synced_folder']['mount_options']
+  end
+  if custom_settings['synced_folder']['type']
+    atlantis_synced_folder_type = custom_settings['synced_folder']['type']
+  end
+  if custom_settings['synced_folder']['smb_username']
+    atlantis_synced_folder_smb_username = custom_settings['synced_folder']['smb_username']
+  end
+  if custom_settings['synced_folder']['smb_password']
+    atlantis_synced_folder_smb_password = custom_settings['synced_folder']['smb_password']
+  end
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
… and load `Vagrantfile.local.yml` only if the file exists.

Fixes an error when running `vagrant global-status --prune`
```
$ vagrant global-status --prune
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/Dominik/Documents/webdev/appflow/Vagrantfile
Line number: 0
Message: Errno::ENOENT: No such file or directory @ rb_sysopen - Vagrantfile.local.yml
```