### PR TITLE
add nodejs and npm support to jailkit

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -20,7 +20,7 @@
   tags: [ common, fail2ban ]
 
 - import_tasks: ssh.yml
-  tags: [ common, ssh, sshd  ]
+  tags: [ common, ssh, sshd ]
 
 - import_tasks: sudo.yml
   tags: [ common, users, sudo ]

--- a/playbooks/roles/common/templates/etc/jailkit/jk_init.ini.j2
+++ b/playbooks/roles/common/templates/etc/jailkit/jk_init.ini.j2
@@ -221,6 +221,11 @@ includesections = xclients
 comment = Ping program
 paths_w_setuid = /bin/ping
 
+[node]
+comment = NodeJS
+executables = /usr/bin/npm, /usr/bin/node, /usr/bin/nodejs
+directories = /usr/lib/node_modules
+
 # [xterm]
 # comment = xterm
 # paths = /usr/bin/X11/xterm, /usr/share/terminfo, /etc/terminfo


### PR DESCRIPTION
add nodejs and npm support inside the chrooted enviroment.